### PR TITLE
use dependabot to bump docker build and base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     schedule:
       interval: "weekly"
 
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 # STEP 1: Build kindnetd binary
-FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23@sha256:7ea4c9dcb2b97ff8ee80a67db3d44f98c8ffa0d191399197007d8459c1453041 AS builder
 ARG TARGETARCH BUILDPLATFORM TARGETPLATFORM
 # copy in sources
 WORKDIR /src
@@ -18,7 +18,7 @@ RUN if [ "$TARGETARCH" = "arm64" ] ; then \
   fi
 
 # STEP 2: Build small image
-FROM --platform=${TARGETPLATFORM} registry.k8s.io/build-image/distroless-iptables:v0.6.6
+FROM --platform=${TARGETPLATFORM} registry.k8s.io/build-image/distroless-iptables:v0.6.6@sha256:be1e8d4d451ada7e39ba4e44fbd8f58ba50feb4f4b1906df7b2bbb424efb06f3
 COPY --from=builder --chown=root:root /go/bin/kindnetd /bin/kindnetd
 COPY --from=builder --chown=root:root /go/bin/cni-kindnet /opt/cni/bin/cni-kindnet
 CMD ["/bin/kindnetd"]


### PR DESCRIPTION
```sh
> crane digest golang:1.23                                           
sha256:7ea4c9dcb2b97ff8ee80a67db3d44f98c8ffa0d191399197007d8459c1453041
> crane digest registry.k8s.io/build-image/distroless-iptables:v0.6.6
sha256:be1e8d4d451ada7e39ba4e44fbd8f58ba50feb4f4b1906df7b2bbb424efb06f3
