### PR TITLE
Portmap local

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN if [ "$TARGETARCH" = "arm64" ] ; then \
   fi
 
 # STEP 2: Build small image
-FROM --platform=${TARGETPLATFORM} registry.k8s.io/build-image/distroless-iptables:v0.6.6@sha256:be1e8d4d451ada7e39ba4e44fbd8f58ba50feb4f4b1906df7b2bbb424efb06f3
+FROM registry.k8s.io/build-image/distroless-iptables:v0.6.6@sha256:be1e8d4d451ada7e39ba4e44fbd8f58ba50feb4f4b1906df7b2bbb424efb06f3
 COPY --from=builder --chown=root:root /go/bin/kindnetd /bin/kindnetd
 COPY --from=builder --chown=root:root /go/bin/cni-kindnet /opt/cni/bin/cni-kindnet
 CMD ["/bin/kindnetd"]

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ clean:
 
 test:
 	CGO_ENABLED=1 go test -v -race -count 1 ./...
+	cd ./cmd/cni-kindnet ; CGO_ENABLED=1 go test -v -race -count 1 .
 
 # code linters
 lint:

--- a/cmd/cni-kindnet/cni_test.go
+++ b/cmd/cni-kindnet/cni_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestCNIPlugin(t *testing.T) {
 	if os.Getuid() != 0 {
-		t.Fatalf("Test requires root privileges.")
+		t.Skip("Test requires root privileges.")
 	}
 	tests := []struct {
 		name   string
@@ -139,7 +139,7 @@ func TestCNIPlugin(t *testing.T) {
 
 func TestAddDel(t *testing.T) {
 	if os.Getuid() != 0 {
-		t.Fatalf("Test requires root privileges.")
+		t.Skip("Test requires root privileges.")
 	}
 
 	now := time.Now()
@@ -250,7 +250,7 @@ func TestAddDel(t *testing.T) {
 
 func TestAdds(t *testing.T) {
 	if os.Getuid() != 0 {
-		t.Fatalf("Test requires root privileges.")
+		t.Skip("Test requires root privileges.")
 	}
 
 	now := time.Now()
@@ -372,7 +372,7 @@ func TestAdds(t *testing.T) {
 
 func TestHostPort(t *testing.T) {
 	if os.Getuid() != 0 {
-		t.Fatalf("Test requires root privileges.")
+		t.Skip("Test requires root privileges.")
 	}
 	containerPort := 8080
 	tests := []struct {

--- a/cmd/cni-kindnet/portmap.go
+++ b/cmd/cni-kindnet/portmap.go
@@ -174,6 +174,18 @@ func reconcilePortMaps() error {
 	*/
 
 	mapLookupV4Expressions := []expr.Any{
+		// only packets destined to local addresses
+		&expr.Fib{
+			Register:       1,
+			FlagDADDR:      true,
+			ResultADDRTYPE: true,
+		},
+		&expr.Cmp{
+			// [ cmp eq reg 1 0x00000002 ]
+			Op:       expr.CmpOpEq,
+			Register: 1,
+			Data:     encodeWithAlignment(byte(unix.RTN_LOCAL)),
+		},
 		&expr.Meta{
 			// [ meta load nfproto => reg 1 ]
 			Key:      expr.MetaKeyNFPROTO,
@@ -224,6 +236,18 @@ func reconcilePortMaps() error {
 	}
 
 	mapLookupV6Expressions := []expr.Any{
+		// only packets destined to local addresses
+		&expr.Fib{
+			Register:       1,
+			FlagDADDR:      true,
+			ResultADDRTYPE: true,
+		},
+		&expr.Cmp{
+			// [ cmp eq reg 1 0x00000002 ]
+			Op:       expr.CmpOpEq,
+			Register: 1,
+			Data:     encodeWithAlignment(byte(unix.RTN_LOCAL)),
+		},
 		&expr.Meta{
 			// [ meta load nfproto => reg 1 ]
 			Key:      expr.MetaKeyNFPROTO,


### PR DESCRIPTION
Portmapping should only be used for packets destined to the local node, otherwise it can hijack legit connections