### PR TITLE
modify install manifest

### DIFF
--- a/install-kindnet.yaml
+++ b/install-kindnet.yaml
@@ -74,7 +74,6 @@ spec:
         k8s-app: kindnet
     spec:
       hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -116,9 +115,7 @@ spec:
             cpu: "100m"
             memory: "50Mi"
         securityContext:
-          privileged: false
-          capabilities:
-            add: ["NET_RAW", "NET_ADMIN"]
+          privileged: true
       volumes:
       - name: cni-bin
         hostPath:


### PR DESCRIPTION
The container needs privileges to write sysctl entries. Depending on the cluster dns have a chicken an egg problem on things like cloud providers, per example, the aws client requires to resolve the aws api endpoint.