### PR TITLE
dnscache: fix ipv6 support

### DIFF
--- a/pkg/dnscache/agent.go
+++ b/pkg/dnscache/agent.go
@@ -431,7 +431,7 @@ func (d *DNSCacheAgent) handleDNSPacket(ctx context.Context, packet network.Pack
 	} else {
 		// no cache entry found so we forward the request via tcp
 		start := time.Now()
-		pool := d.tcpPool.Get(packet.DstIP.String() + ":53")
+		pool := d.tcpPool.Get(net.JoinHostPort(packet.DstIP.String(), "53"))
 		conn, err := pool.Get()
 		if err != nil {
 			klog.Error(err, "fail to get TCP connection from pool")

--- a/pkg/dnscache/dnsclient.go
+++ b/pkg/dnscache/dnsclient.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"syscall"
 
 	"github.com/aojea/kindnet/pkg/network"
@@ -236,7 +237,7 @@ func dnsResponseRoundtrip(packet network.Packet, data []byte) error {
 			})
 		},
 	}
-	conn, err := freebindDialer.Dial("udp", fmt.Sprintf("%s:%d", packet.SrcIP.String(), packet.SrcPort))
+	conn, err := freebindDialer.Dial("udp", net.JoinHostPort(packet.SrcIP.String(), strconv.Itoa(packet.SrcPort)))
 	if err != nil {
 		return fmt.Errorf("can not dial to %s:%d : %w", packet.SrcIP.String(), packet.SrcPort, err)
 	}


### PR DESCRIPTION
Seen in https://testgrid.k8s.io/kops-distro-u2404#kops-aws-cni-kindnet-ipv6

It fails with

> 113 11:39:10.199522       1 agent.go:438] address fd00:5e4f:ce::a:53: too many colons in addressfail to get TCP connection from pool
> I0113 11:39:10.199578       1 agent.go:170] "Finished syncing packet" id=508 duration="81.961µs" verdict="accept"
> I0113 11:39:10.236631       1 agent.go:154] "Processing sync for packet" id=509

good thing is that it does not impact the connectivity