### PR TITLE
support ipsec tunnels

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         ipFamily: ["ipv4", "ipv6", "dual"]
-        cniMode: ["ptp"]
+        cniMode: ["ptp","ipsec"]
     env:
       JOB_NAME: "kindnetd-e2e-${{ matrix.ipFamily }}-${{ matrix.cniMode }}"
       IP_FAMILY: ${{ matrix.ipFamily }}
@@ -129,11 +129,12 @@ jobs:
         sed -i s#aojea/kindnetd.*#aojea/kindnetd:test# install-kindnet.yaml
         /usr/local/bin/kubectl apply -f ./install-kindnet.yaml
 
-    - name: install bridge plugin
-      if: ${{ matrix.cniMode == 'bridge' }}
+    - name: enable ipsec
+      if: ${{ matrix.cniMode == 'ipsec' }}
       run: |
-        sed -i s#aojea/kindnetd.*#aojea/kindnetd:test# install-kindnet-bridge.yaml
-        /usr/local/bin/kubectl apply -f ./install-kindnet-bridge.yaml
+        sed -i s#aojea/kindnetd.*#aojea/kindnetd:test# install-kindnet.yaml
+        sed -i s#ipsec-overlay=false#ipsec-overlay=true# install-kindnet.yaml
+        /usr/local/bin/kubectl apply -f ./install-kindnet.yaml
 
     - name: Get Cluster status
       run: |

--- a/cmd/kindnetd/main.go
+++ b/cmd/kindnetd/main.go
@@ -81,6 +81,7 @@ var (
 	fastpathThreshold          int
 	disableCNI                 bool
 	nflogLevel                 int
+	ipsecOverlay               bool
 )
 
 func init() {
@@ -98,6 +99,7 @@ func init() {
 	flag.IntVar(&fastpathThreshold, "fastpath-threshold", 20, "The number of packets after the traffic is offloaded to the fast path, zero disables it (default 20). Set to zero to disable it")
 
 	flag.IntVar(&nflogLevel, "nflog-level", 9, "The log level at which the TCP and UDP packets are logged to stdout (default 9)")
+	flag.BoolVar(&ipsecOverlay, "ipsec-overlay", false, "use IPSec to tunnel traffic between nodes (default false)")
 
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, "Usage: kindnet [options]\n\n")
@@ -216,7 +218,7 @@ func main() {
 
 	// node controller handles CNI config for our own node and routes to the others
 	if !disableCNI {
-		nodeController := kindnetnode.NewNodeController(nodeName, clientset, nodeInformer)
+		nodeController := kindnetnode.NewNodeController(nodeName, clientset, nodeInformer, ipsecOverlay)
 		go func() {
 			err := nodeController.Run(ctx, 5)
 			if err != nil {

--- a/install-kindnet.yaml
+++ b/install-kindnet.yaml
@@ -98,6 +98,15 @@ spec:
         command:
         - /bin/kindnetd
         - --hostname-override=$(NODE_NAME)
+        - --network-policy=true
+        - --admin-network-policy=false
+        - --baseline-admin-network-policy=false
+        - --masquerading=true
+        - --dns-caching=true
+        - --disable-cni=false
+        - --fastpath-threshold=20
+        - --ipsec-overlay=false
+        - --nat64=true
         - --v=2
         env:
         - name: HOST_IP

--- a/pkg/node/cni.go
+++ b/pkg/node/cni.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"k8s.io/klog/v2"
 )
 
 /* cni config management */
@@ -84,5 +86,6 @@ func WriteCNIConfig(ranges []string) (err error) {
 		_ = os.Remove(cniFile)
 		return err
 	}
+	klog.Infof("CNI config file succesfully written")
 	return nil
 }

--- a/pkg/node/ipsec.go
+++ b/pkg/node/ipsec.go
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: APACHE-2.0
+
+package node
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/vishvananda/netlink"
+
+	v1 "k8s.io/api/core/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
+)
+
+const (
+	ipsecIface   = "knet-xfrm0"
+	ipsecIfaceID = 1001
+	spi          = 1001
+	// use the serviceaccount token as key for encryption
+	tokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+)
+
+func getKey() ([]byte, error) {
+	token, err := os.ReadFile(tokenFile)
+	if err != nil {
+		return nil, err
+	}
+	return token[:16], nil
+}
+
+func (c *NodeController) initIPsec() error {
+	xfrm := &netlink.Xfrmi{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: ipsecIface,
+		},
+		Ifid: ipsecIfaceID,
+	}
+
+	if err := netlink.LinkAdd(xfrm); err != nil {
+		klog.Infof("failed to add XFRM interface: %v", err)
+	}
+
+	if err := netlink.LinkSetUp(xfrm); err != nil {
+		return fmt.Errorf("failed to set up XFRM interface: %v", err)
+	}
+	for _, podCIDR := range c.localPodCIDRs {
+		_, cidr, err := net.ParseCIDR(podCIDR)
+		if err != nil {
+			return err
+		}
+		_, ones := cidr.Mask.Size()
+		cidr.Mask = net.CIDRMask(ones, ones)
+		// use the network address as IP of the interface
+		if err := netlink.AddrAdd(xfrm, &netlink.Addr{IPNet: cidr}); err != nil {
+			return fmt.Errorf("failed to add address to xfrm interface: %v", err)
+		}
+	}
+	return nil
+}
+
+// instructions from https://blog.hansenpartnership.com/figuring-out-how-ipsec-transforms-work-in-linux/
+func (c *NodeController) syncIPSecPolicies(node *v1.Node) error {
+	errs := []error{}
+	nodeIPs, err := GetNodeHostIPs(node)
+	if err != nil {
+		return err
+	}
+
+	key, err := getKey()
+	if err != nil {
+		return err
+	}
+
+	for _, nodeIP := range nodeIPs {
+		for _, podCIDR := range node.Spec.PodCIDRs {
+			// check PodCIDR is the same IP family
+			if netutils.IsIPv6CIDRString(podCIDR) != netutils.IsIPv6(nodeIP) {
+				continue
+			}
+
+			var srcIP net.IP
+			for _, ip := range c.localPodIPs {
+				if netutils.IsIPv6CIDRString(podCIDR) == netutils.IsIPv6(ip) {
+					srcIP = ip
+					break
+				}
+			}
+
+			if srcIP == nil {
+				continue
+			}
+
+			var srcNet *net.IPNet
+			for _, cidr := range c.localPodCIDRs {
+				if netutils.IsIPv6CIDRString(podCIDR) == netutils.IsIPv6CIDRString(cidr) {
+					_, ipnet, err := net.ParseCIDR(cidr)
+					if err != nil {
+						return err
+					}
+					srcNet = ipnet
+					break
+				}
+			}
+			if srcNet == nil {
+				continue
+			}
+
+			_, dstNet, err := net.ParseCIDR(podCIDR)
+			if err != nil {
+				return err
+			}
+
+			link, err := netlink.LinkByName(ipsecIface)
+			if err != nil {
+				return fmt.Errorf("failed to get link by name: %v", err)
+			}
+
+			route := &netlink.Route{
+				Dst:       dstNet,
+				LinkIndex: link.Attrs().Index,
+			}
+
+			// Check if the route already exists.
+			existingRoutes, err := netlink.RouteListFiltered(netlink.FAMILY_ALL, route, netlink.RT_FILTER_DST)
+			if err != nil && !errors.Is(err, netlink.ErrDumpInterrupted) {
+				return fmt.Errorf("failed to list routes: %v", err)
+			}
+
+			if len(existingRoutes) == 0 {
+				// Route does not exist, add it.
+				if err := netlink.RouteAdd(route); err != nil {
+					return fmt.Errorf("failed to add route: %v", err)
+				}
+			} else if existingRoutes[0].LinkIndex != link.Attrs().Index {
+				if err := netlink.RouteReplace(route); err != nil {
+					return fmt.Errorf("failed to replace route: %v", err)
+				}
+			}
+
+			// state transform for encapsulation
+			state := &netlink.XfrmState{
+				Src:   srcIP,
+				Dst:   nodeIP,
+				Proto: netlink.XFRM_PROTO_ESP,
+				Mode:  netlink.XFRM_MODE_TUNNEL,
+				Spi:   int(spi),
+				Ifid:  ipsecIfaceID,
+				Crypt: &netlink.XfrmStateAlgo{
+					Name: "cbc(aes)",
+					Key:  key,
+				},
+			}
+
+			err = netlink.XfrmStateAdd(state)
+			if err != nil {
+				klog.Infof("failed to add xfrm state %v : %v", state, err)
+				if err := netlink.XfrmStateUpdate(state); err != nil {
+					errs = append(errs, fmt.Errorf("failed to update XFRM state: %v", err))
+				}
+			}
+
+			// automatic decapsulation
+			state = &netlink.XfrmState{
+				Src:   nodeIP,
+				Dst:   srcIP,
+				Proto: netlink.XFRM_PROTO_ESP,
+				Mode:  netlink.XFRM_MODE_TUNNEL,
+				Spi:   int(spi),
+				Ifid:  ipsecIfaceID,
+				Crypt: &netlink.XfrmStateAlgo{
+					Name: "cbc(aes)",
+					Key:  key,
+				},
+			}
+			err = netlink.XfrmStateAdd(state)
+			if err != nil {
+				klog.Infof("failed to add xfrm state %v : %v", state, err)
+				if err := netlink.XfrmStateUpdate(state); err != nil {
+					errs = append(errs, fmt.Errorf("failed to update XFRM state: %v", err))
+				}
+			}
+
+			// required policy for encapsulation
+			policy := &netlink.XfrmPolicy{
+				Src:  srcNet,
+				Dst:  dstNet,
+				Dir:  netlink.XFRM_DIR_OUT,
+				Ifid: ipsecIfaceID,
+				Tmpls: []netlink.XfrmPolicyTmpl{{
+					Src:   srcIP,
+					Dst:   nodeIP,
+					Proto: netlink.XFRM_PROTO_ESP,
+					Mode:  netlink.XFRM_MODE_TUNNEL,
+					Spi:   int(spi),
+				}},
+			}
+			// Look for a specific policy
+			sp, err := netlink.XfrmPolicyGet(policy)
+			if err != nil {
+				klog.Infof("failed to get xfrm policy %v : %v", policy, err)
+			}
+			if sp != nil {
+				klog.V(4).InfoS("xfrm policy already exist", "policy", sp)
+			} else {
+				err = netlink.XfrmPolicyAdd(policy)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("failed to add xfrm policy %v : %v", policy, err))
+				}
+			}
+
+			// policy to allow passing of decapsulated packets
+			policy = &netlink.XfrmPolicy{
+				Dst:  srcNet,
+				Dir:  netlink.XFRM_DIR_IN,
+				Ifid: ipsecIfaceID,
+				Tmpls: []netlink.XfrmPolicyTmpl{{
+					Proto: netlink.XFRM_PROTO_ESP,
+					Mode:  netlink.XFRM_MODE_TUNNEL,
+					Spi:   int(spi),
+				}},
+			}
+			err = netlink.XfrmPolicyAdd(policy)
+			if err != nil {
+				klog.Infof("failed to add xfrm policy %v : %v", policy, err)
+				if err = netlink.XfrmPolicyUpdate(policy); err != nil {
+					errs = append(errs, fmt.Errorf("failed to update XFRM policy: %v", err))
+				}
+			}
+
+			// policy to allow passing of decapsulated packets
+			policy = &netlink.XfrmPolicy{
+				Dst:  srcNet,
+				Dir:  netlink.XFRM_DIR_FWD,
+				Ifid: ipsecIfaceID,
+				Tmpls: []netlink.XfrmPolicyTmpl{{
+					Proto: netlink.XFRM_PROTO_ESP,
+					Mode:  netlink.XFRM_MODE_TUNNEL,
+					Spi:   int(spi),
+				}},
+			}
+			err = netlink.XfrmPolicyAdd(policy)
+			if err != nil {
+				klog.Infof("failed to add xfrm policy %v : %v", policy, err)
+				if err := netlink.XfrmPolicyUpdate(policy); err != nil {
+					errs = append(errs, fmt.Errorf("failed to update XFRM policy: %v", err))
+				}
+			}
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+func deleteIPSecPolicies(node *v1.Node) error {
+	errs := []error{}
+
+	nodeIPs, err := GetNodeHostIPs(node)
+	if err != nil {
+		return err
+	}
+
+	for _, nodeIP := range nodeIPs {
+		for _, podCIDR := range node.Spec.PodCIDRs {
+			// check PodCIDR is the same IP family
+			if netutils.IsIPv6CIDRString(podCIDR) != netutils.IsIPv6(nodeIP) {
+				continue
+			}
+
+			family := netlink.FAMILY_V4
+			if netutils.IsIPv6(nodeIP) {
+				family = netlink.FAMILY_V6
+			}
+
+			_, dstNet, err := net.ParseCIDR(podCIDR)
+			if err != nil {
+				return err
+			}
+
+			states, err := netlink.XfrmStateList(family)
+			if err != nil {
+				return fmt.Errorf("failed to get all the xfrm states: %v", err)
+			}
+
+			for _, state := range states {
+				if state.Dst.Equal(nodeIP) {
+					err := netlink.XfrmStateDel(&state)
+					if err != nil {
+						errs = append(errs, fmt.Errorf("failed to delete xfrm state %s: %v", state.String(), err))
+
+					}
+					break
+				}
+			}
+
+			policies, err := netlink.XfrmPolicyList(family)
+			if err != nil {
+				return fmt.Errorf("failed to get all the xfrm states: %v", err)
+			}
+
+			for _, policy := range policies {
+				if policy.Dst.String() == dstNet.String() {
+					err := netlink.XfrmPolicyDel(&policy)
+					if err != nil {
+						errs = append(errs, fmt.Errorf("failed to delete xfrm policy %s: %v", policy.String(), err))
+					}
+					break
+				}
+			}
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+func cleanIPSecPolicies() error {
+	states, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+	if err != nil {
+		return fmt.Errorf("failed to get all the xfrm states: %v", err)
+	}
+
+	for _, state := range states {
+		if state.Ifid == ipsecIfaceID {
+			err := netlink.XfrmStateDel(&state)
+			if err != nil {
+				klog.Infof("failed to delete xfrm state %s : %v", state.String(), err)
+			}
+		}
+	}
+
+	policies, err := netlink.XfrmPolicyList(netlink.FAMILY_ALL)
+	if err != nil {
+		return fmt.Errorf("failed to get all the xfrm states: %v", err)
+	}
+
+	for _, policy := range policies {
+		if policy.Ifid == ipsecIfaceID {
+			err := netlink.XfrmPolicyDel(&policy)
+			if err != nil {
+				klog.Infof("failed to delete xfrm policy %s: %v", policy.String(), err)
+			}
+		}
+	}
+	return nil
+}
+
+func cleanIPSecInterface() error {
+	ifaces, err := netlink.LinkList()
+	if err != nil {
+		return err
+	}
+	for _, iface := range ifaces {
+		if iface.Attrs().Name == ipsecIface {
+			return netlink.LinkDel(iface)
+		}
+		xfrmi, ok := iface.(*netlink.Xfrmi)
+		if !ok {
+			continue
+		}
+		if xfrmi.Ifid == ipsecIfaceID {
+			return netlink.LinkDel(iface)
+		}
+	}
+	return nil
+}

--- a/pkg/node/routes.go
+++ b/pkg/node/routes.go
@@ -32,7 +32,7 @@ func syncRoute(node *v1.Node) error {
 		addRoute := true
 		for _, route := range routes {
 			if route.Gw != nil {
-				klog.Infof("Route to Node %s via %s, no direct routing needed, if pods can not communicate please configure your router correctly", nodeIP, route.Gw.String())
+				klog.V(2).Infof("Route to Node %s via %s, no direct routing needed, if pods can not communicate please configure your router correctly", nodeIP, route.Gw.String())
 				addRoute = false
 				break
 			}
@@ -64,6 +64,11 @@ func syncRoute(node *v1.Node) error {
 			if len(routes) == 0 {
 				klog.Infof("Adding route %v \n", dst)
 				if err := netlink.RouteAdd(&routeToDst); err != nil {
+					return err
+				}
+			} else if len(routes) > 0 && !routes[0].Gw.Equal(nodeIP) {
+				klog.Infof("Replaceing route %v \n", dst)
+				if err := netlink.RouteReplace(&routeToDst); err != nil {
 					return err
 				}
 			}

--- a/site/content/docs/user/ipsec/index.md
+++ b/site/content/docs/user/ipsec/index.md
@@ -1,0 +1,13 @@
+---
+title: "IPSec"
+date: 2025-01-17T12:39:58Z
+Weight: 60
+---
+
+Kindnet provides an overlay network that enables communication between Pods and nodes within a Kind cluster using IPsec tunnels.
+
+IPsec encrypts and authenticates traffic between nodes, ensuring confidentiality and integrity. This is especially important in clusters where the underlying network might not be trusted (e.g., a shared development network).
+
+### IPsec Tunnel Mode in kindnetd
+
+kindnetd leverages IPsec tunnel mode to create an overlay network that functions independently of the underlying network infrastructure. This is often referred to as "island mode" because the Kind cluster operates as a self-contained network island, isolated from the surrounding network.


### PR DESCRIPTION
Add support to ipsec tunnels between nodes, so it can serve two purposes, provide and overlay and offer end to end encryption between nodes.

The key is the service account token

It supports seamless migration, just by switching the flag to false or to true, just notice the impact on ping latency

```
64 bytes from 10.244.1.32: icmp_seq=45 ttl=62 time=0.084 ms
64 bytes from 10.244.1.32: icmp_seq=46 ttl=62 time=0.081 ms
64 bytes from 10.244.1.32: icmp_seq=47 ttl=62 time=0.086 ms
64 bytes from 10.244.1.32: icmp_seq=48 ttl=62 time=0.087 ms
64 bytes from 10.244.1.32: icmp_seq=52 ttl=62 time=0.139 ms. <---
64 bytes from 10.244.1.32: icmp_seq=53 ttl=62 time=0.148 ms
64 bytes from 10.244.1.32: icmp_seq=54 ttl=62 time=0.156 ms
64 bytes from 10.244.1.32: icmp_seq=55 ttl=62 time=0.133 ms
````