### PR TITLE
Migrations

### DIFF
--- a/cmd/kindnetd/main.go
+++ b/cmd/kindnetd/main.go
@@ -252,13 +252,13 @@ func main() {
 		}
 
 		go func() {
-			defer nat64Agent.CleanRules()
 			if err := nat64Agent.Run(ctx); err != nil {
 				klog.Infof("error running nat64 agent: %v", err)
 			}
 		}()
 	} else {
-		klog.Info("Skipping nat64 agent")
+		klog.Info("Skipping nat64 agent, cleaning old rules")
+		kindnetnat64.CleanRules()
 	}
 
 	// create a dnsCacheAgent

--- a/cmd/kindnetd/main.go
+++ b/cmd/kindnetd/main.go
@@ -270,13 +270,13 @@ func main() {
 		}
 
 		go func() {
-			defer dnsCacheAgent.CleanRules()
 			if err := dnsCacheAgent.Run(ctx); err != nil {
 				klog.Infof("error running dnsCacheAgent agent: %v", err)
 			}
 		}()
 	} else {
-		klog.Info("Skipping dnsCacheAgent")
+		klog.Info("Skipping dnsCacheAgent, cleaning old rules")
+		defer dnscache.CleanRules()
 	}
 
 	if fastpathThreshold > 0 {

--- a/cmd/kindnetd/main.go
+++ b/cmd/kindnetd/main.go
@@ -234,13 +234,13 @@ func main() {
 		}
 
 		go func() {
-			defer masqAgent.CleanRules()
 			if err := masqAgent.Run(ctx); err != nil {
 				klog.Infof("error running masquerading agent: %v", err)
 			}
 		}()
 	} else {
-		klog.Info("Skipping ipMasqAgent")
+		klog.Info("Skipping ipMasqAgent, cleaning up old rules")
+		masq.CleanRules()
 	}
 
 	// create an nat64 agent if nat64 is enabled and is an IPv6 only cluster
@@ -286,13 +286,13 @@ func main() {
 			klog.Fatalf("error creating fastpath agent: %v", err)
 		}
 		go func() {
-			defer fastpathAgent.CleanRules()
 			if err := fastpathAgent.Run(ctx); err != nil {
 				klog.Infof("error running fastpathAgent: %v", err)
 			}
 		}()
 	} else {
-		klog.Info("Skipping fastpathAgent")
+		klog.Info("Skipping fastpathAgent, cleaning old rules")
+		fastpath.CleanRules()
 	}
 
 	if klog.V(klog.Level(nflogLevel)).Enabled() {

--- a/cmd/kindnetd/main.go
+++ b/cmd/kindnetd/main.go
@@ -308,7 +308,7 @@ func main() {
 		}()
 	} else {
 		klog.Info("Skipping nflog agent, cleaning old rules")
-		nflogAgent.CleanRules()
+		nflog.CleanRules()
 	}
 
 	// network policies

--- a/cmd/kindnetd/main.go
+++ b/cmd/kindnetd/main.go
@@ -276,7 +276,7 @@ func main() {
 		}()
 	} else {
 		klog.Info("Skipping dnsCacheAgent, cleaning old rules")
-		defer dnscache.CleanRules()
+		dnscache.CleanRules()
 	}
 
 	if fastpathThreshold > 0 {

--- a/cmd/kindnetd/main.go
+++ b/cmd/kindnetd/main.go
@@ -302,13 +302,13 @@ func main() {
 			klog.Fatalf("error creating nflog agent: %v", err)
 		}
 		go func() {
-			defer nflogAgent.CleanRules()
 			if err := nflogAgent.Run(ctx); err != nil {
 				klog.Infof("error running nflog: %v", err)
 			}
 		}()
 	} else {
-		klog.Info("Skipping nflog agent")
+		klog.Info("Skipping nflog agent, cleaning old rules")
+		nflogAgent.CleanRules()
 	}
 
 	// network policies

--- a/pkg/dnscache/agent.go
+++ b/pkg/dnscache/agent.go
@@ -398,7 +398,7 @@ func (d *DNSCacheAgent) SyncRules(ctx context.Context) error {
 	return nil
 }
 
-func (d *DNSCacheAgent) CleanRules() {
+func CleanRules() {
 	nft, err := nftables.New()
 	if err != nil {
 		klog.Errorf("can not start nftables:%v", err)

--- a/pkg/dnscache/agent_test.go
+++ b/pkg/dnscache/agent_test.go
@@ -135,7 +135,7 @@ table inet kindnet-dnscache {
 			if !compareMultilineStringsIgnoreIndentation(got, tt.expectedNftables) {
 				t.Errorf("Got:\n%s\nExpected:\n%s\nDiff:\n%s", got, tt.expectedNftables, cmp.Diff(got, tt.expectedNftables))
 			}
-			n.CleanRules()
+			CleanRules()
 			cmd = exec.Command("nft", "list", "table", "inet", tableName)
 			out, err = cmd.CombinedOutput()
 			if err == nil {

--- a/pkg/fastpath/fastpath.go
+++ b/pkg/fastpath/fastpath.go
@@ -209,7 +209,7 @@ func (ma *FastPathAgent) syncRules(devices []string) error {
 	return nil
 }
 
-func (ma *FastPathAgent) CleanRules() {
+func CleanRules() {
 	nft, err := nftables.New()
 	if err != nil {
 		klog.Infof("fastpath cleanup failure, can not start nftables:%v", err)

--- a/pkg/fastpath/fastpath_test.go
+++ b/pkg/fastpath/fastpath_test.go
@@ -78,7 +78,7 @@ table inet kindnet-fastpath {
 			if !compareMultilineStringsIgnoreIndentation(got, tt.expectedNftables) {
 				t.Errorf("Got:\n%s\nExpected:\n%s\nDiff:\n%s", got, tt.expectedNftables, cmp.Diff(got, tt.expectedNftables))
 			}
-			n.CleanRules()
+			CleanRules()
 			cmd = exec.Command("nft", "list", "table", "inet", tableName)
 			out, err = cmd.CombinedOutput()
 			if err == nil {

--- a/pkg/masq/masq.go
+++ b/pkg/masq/masq.go
@@ -325,7 +325,7 @@ func (ma *IPMasqAgent) SyncRules(ctx context.Context) error {
 	return nil
 }
 
-func (ma *IPMasqAgent) CleanRules() {
+func CleanRules() {
 	nft, err := nftables.New()
 	if err != nil {
 		klog.Infof("ipmasq cleanup failure, can not start nftables:%v", err)

--- a/pkg/masq/masq_test.go
+++ b/pkg/masq/masq_test.go
@@ -258,7 +258,7 @@ table inet kindnet-ipmasq {
 			if !compareMultilineStringsIgnoreIndentation(got, tt.expectedNftables) {
 				t.Errorf("Got:\n%s\nExpected:\n%s\nDiff:\n%s", got, tt.expectedNftables, cmp.Diff(got, tt.expectedNftables))
 			}
-			ma.CleanRules()
+			CleanRules()
 			cmd = exec.Command("nft", "list", "table", "inet", tableName)
 			out, err = cmd.CombinedOutput()
 			if err == nil {

--- a/pkg/nat64/proxy.go
+++ b/pkg/nat64/proxy.go
@@ -306,7 +306,7 @@ func (n *NAT64Agent) SyncRules(ctx context.Context) error {
 	return nil
 }
 
-func (n *NAT64Agent) CleanRules() {
+func CleanRules() {
 	nft, err := nftables.New()
 	if err != nil {
 		klog.Infof("nat64 cleanup failure, can not start nftables:%v", err)

--- a/pkg/nat64/proxy_test.go
+++ b/pkg/nat64/proxy_test.go
@@ -74,7 +74,7 @@ func TestNAT64Agent_SyncRules(t *testing.T) {
 			if !compareMultilineStringsIgnoreIndentation(got, tt.expectedNftables) {
 				t.Errorf("Got:\n%s\nExpected:\n%s\nDiff:\n%s", got, tt.expectedNftables, cmp.Diff(got, tt.expectedNftables))
 			}
-			n.CleanRules()
+			CleanRules()
 			cmd = exec.Command("nft", "list", "table", "ip6", tableName)
 			out, err = cmd.CombinedOutput()
 			if err == nil {

--- a/pkg/nflog/nflog.go
+++ b/pkg/nflog/nflog.go
@@ -138,7 +138,7 @@ func (n *NFLogAgent) syncRules() error {
 	return nil
 }
 
-func (n *NFLogAgent) CleanRules() {
+func CleanRules() {
 	nft, err := nftables.New()
 	if err != nil {
 		klog.Infof("fastpath cleanup failure, can not start nftables:%v", err)

--- a/pkg/nflog/nflog_test.go
+++ b/pkg/nflog/nflog_test.go
@@ -69,7 +69,7 @@ table inet kindnet-nflog {
 			if !compareMultilineStringsIgnoreIndentation(got, tt.expectedNftables) {
 				t.Errorf("Got:\n%s\nExpected:\n%s\nDiff:\n%s", got, tt.expectedNftables, cmp.Diff(got, tt.expectedNftables))
 			}
-			n.CleanRules()
+			CleanRules()
 			cmd = exec.Command("nft", "list", "table", "inet", tableName)
 			out, err = cmd.CombinedOutput()
 			if err == nil {


### PR DESCRIPTION
We can not delete the nftables rules on exit or there will be disruption during upgrades, however, we can not leave those rules enabled if the feature is not available, in case there are configuration changes