### PR TITLE
fix a typo in masq agent is daddr instead of saddr

### DIFF
--- a/pkg/masq/masq.go
+++ b/pkg/masq/masq.go
@@ -278,7 +278,7 @@ func (ma *IPMasqAgent) SyncRules(ctx context.Context) error {
 		Table: table,
 		Chain: chain,
 		Exprs: []expr.Any{
-			&expr.Fib{Register: 0x1, FlagSADDR: true, ResultADDRTYPE: true},
+			&expr.Fib{Register: 0x1, FlagDADDR: true, ResultADDRTYPE: true},
 			&expr.Cmp{Op: expr.CmpOpEq, Register: 0x1, Data: network.EncodeWithAlignment(byte(unix.RTN_LOCAL))},
 			&expr.Verdict{Kind: expr.VerdictAccept},
 		},

--- a/pkg/masq/masq_test.go
+++ b/pkg/masq/masq_test.go
@@ -52,7 +52,7 @@ table inet kindnet-ipmasq {
       chain postrouting {
               type nat hook postrouting priority srcnat - 10; policy accept;
               ct state established,related accept
-              fib saddr type local accept
+              fib daddr type local accept
               ip daddr @noMasqV4 accept
               ip6 daddr @noMasqV6 accept
               masquerade counter packets 0 bytes 0
@@ -86,7 +86,7 @@ table inet kindnet-ipmasq {
       chain postrouting {
               type nat hook postrouting priority srcnat - 10; policy accept;
               ct state established,related accept
-              fib saddr type local accept
+              fib daddr type local accept
               ip daddr @noMasqV4 accept
               ip6 daddr @noMasqV6 accept
               masquerade counter packets 0 bytes 0
@@ -121,7 +121,7 @@ table inet kindnet-ipmasq {
       chain postrouting {
               type nat hook postrouting priority srcnat - 10; policy accept;
               ct state established,related accept
-              fib saddr type local accept
+              fib daddr type local accept
               ip daddr @noMasqV4 accept
               ip6 daddr @noMasqV6 accept
               masquerade counter packets 0 bytes 0
@@ -156,7 +156,7 @@ table inet kindnet-ipmasq {
       chain postrouting {
               type nat hook postrouting priority srcnat - 10; policy accept;
               ct state established,related accept
-              fib saddr type local accept
+              fib daddr type local accept
               ip daddr @noMasqV4 accept
               ip6 daddr @noMasqV6 accept
               masquerade counter packets 0 bytes 0
@@ -195,7 +195,7 @@ table inet kindnet-ipmasq {
       chain postrouting {
               type nat hook postrouting priority srcnat - 10; policy accept;
               ct state established,related accept
-              fib saddr type local accept
+              fib daddr type local accept
               ip daddr @noMasqV4 accept
               ip6 daddr @noMasqV6 accept
               masquerade counter packets 0 bytes 0


### PR DESCRIPTION
The comment was right 

> 	// fib daddr type local accept comment "skip local traffic"

the implementation was wrong, we want to masquerade all traffic that is NO directed to LOCAL addresses